### PR TITLE
Fix knowledge base and release info navigation

### DIFF
--- a/lib/screens/feedback/feedback_screen.dart
+++ b/lib/screens/feedback/feedback_screen.dart
@@ -355,9 +355,8 @@ class _FeedbackScreenState extends State<FeedbackScreen> {
             const SizedBox(height: 16),
             ElevatedButton.icon(
               onPressed: () {
-                // Navigate to Release Info screen (ScreenType.versions)
-                Navigator.of(context).pop(); // Go back to project dashboard
-                // The user can then navigate to Release Info manually
+                Provider.of<MenuAppController>(context, listen: false)
+                    .changeScreen(ScreenType.versions);
               },
               icon: const Icon(Icons.settings),
               label: const Text('Go to Release Info'),

--- a/lib/screens/game_design_assistant/game_design_assistant_screen.dart
+++ b/lib/screens/game_design_assistant/game_design_assistant_screen.dart
@@ -21,6 +21,7 @@ import '../../services/mutation_design_service.dart';
 import '../../services/feedback_discussion_service.dart';
 import '../../services/projects_api_service.dart';
 import '../../models/feedback_models.dart' as feedback_models;
+import '../../controllers/menu_app_controller.dart';
 
 /// Game Design Assistant Screen using Flutter Gen AI Chat UI
 class GameDesignAssistantScreen extends StatefulWidget {
@@ -1041,14 +1042,12 @@ Ask me anything about game design, or try one of the example questions below!
   }
 
   void _showKnowledgeBase() {
-    // Simply show a message - user can navigate to Knowledge Base screen from menu
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text('Navigate to Knowledge Base screen from the menu to view all documents'),
-        backgroundColor: Colors.blue,
-      ),
-    );
-    
+    if (!mounted) return;
+
+    // Navigate to the Knowledge Base screen within the current project
+    Provider.of<MenuAppController>(context, listen: false)
+        .changeScreen(ScreenType.knowledgeBase);
+
     /* Old implementation with modal - removed as it relied on ProjectProvider
     showModalBottomSheet(
       context: context,


### PR DESCRIPTION
## Summary
- add knowledge base navigation from the Game Design Assistant header
- keep feedback users within the project by routing the Release Info shortcut to the correct panel

## Testing
- Not run (environment missing Dart SDK)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e8e91085c83289a4003896de46160)